### PR TITLE
Show total cost for found visits and total client's paid value for selected time period

### DIFF
--- a/app/schemas/page.py
+++ b/app/schemas/page.py
@@ -15,4 +15,4 @@ class PageResponse(BaseModel, Generic[T]):
 
 
 class PageVisitResponse(PageResponse[VisitResponse]):
-    total_cost: int = 0
+    total_cost: float = 0

--- a/app/utils/visit/database.py
+++ b/app/utils/visit/database.py
@@ -86,13 +86,17 @@ async def dal_count_visits_by_filter(
 async def dal_total_visits_cost_by_filter(
         session: AsyncSession,
         search: VisitSearchRequest,
-) -> int:
+) -> float:
+    filtered_costs = _search_stmt(
+        search,
+        select(Visit.cost.label("cost")),
+    ).subquery()
+
     result = await session.scalar(
-        select(func.sum(Visit.cost)).select_from(
-            _search_stmt(search, select(Visit)).subquery()
-        )
+        select(func.coalesce(func.sum(filtered_costs.c.cost), 0))
     )
-    return result or 0
+
+    return float(result)
 
 
 # --- HELPERS ---

--- a/web/src/api/visits.ts
+++ b/web/src/api/visits.ts
@@ -1,0 +1,27 @@
+import { api } from '../lib/api'
+import type { VisitResponse, VisitStatusEnum } from '.'
+
+export type VisitQueryParams = {
+    limit?: number
+    offset?: number
+    client_id?: string
+    doctor_id?: string
+    start_date?: string
+    end_date?: string
+    cabinet?: string
+    procedure?: string
+    status?: VisitStatusEnum
+}
+
+export type VisitPageResponse = {
+    total: number
+    limit: number
+    offset: number
+    items: VisitResponse[]
+    total_cost?: number
+}
+
+export async function fetchVisits(params: VisitQueryParams): Promise<VisitPageResponse> {
+    const res = await api.get<VisitPageResponse>('/visits/', { params })
+    return res.data
+}

--- a/web/src/components/visits/VisitsManager.tsx
+++ b/web/src/components/visits/VisitsManager.tsx
@@ -967,7 +967,7 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
 
                 <Space size="small" align="center">
                     <Typography.Text type="secondary">
-                        Суммарная стоимость приёмов:
+                        Суммарная стоимость найденных приёмов:
                     </Typography.Text>
                     <Typography.Text strong>{totalCostDisplay}</Typography.Text>
                 </Space>

--- a/web/src/pages/ClientProfilePage.tsx
+++ b/web/src/pages/ClientProfilePage.tsx
@@ -1,8 +1,11 @@
+import { useCallback, useMemo, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import dayjs from 'dayjs'
 import { api } from '../lib/api'
-import type { ClientResponse } from '../api'
-import { Button, Card, Col, Row, Skeleton, Typography } from 'antd'
+import type { ClientResponse, VisitStatusEnum } from '../api'
+import { Button, Card, Col, Row, Select, Skeleton, Space, Typography } from 'antd'
+import { fetchVisits, type VisitQueryParams } from '../api/visits'
 import VisitsManager from '../components/visits/VisitsManager'
 
 async function fetchClient(id: string): Promise<ClientResponse> {
@@ -10,16 +13,73 @@ async function fetchClient(id: string): Promise<ClientResponse> {
     return res.data
 }
 
+type YearFilterValue = 'all' | number
+
 export default function ClientProfilePage() {
     const { id } = useParams<{ id: string }>()
     const navigate = useNavigate()
-    if (!id) return <div>Некорректный id</div>
+    const queryClient = useQueryClient()
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { data: client, isLoading } = useQuery({
         queryKey: ['client', id],
-        queryFn: () => fetchClient(id),
+        enabled: !!id,
+        queryFn: () => fetchClient(id!),
     })
+
+    const [selectedYear, setSelectedYear] = useState<YearFilterValue>('all')
+    const yearOptions = useMemo(() => {
+        const currentYear = dayjs().year()
+        const years = Array.from({length: 10}, (_, idx) => currentYear - idx)
+        return [
+            {value: 'all' as YearFilterValue, label: 'За всё время'},
+            ...years.map(year => ({value: year as YearFilterValue, label: String(year)})),
+        ]
+    }, [])
+
+    const currencyFormatter = useMemo(
+        () => new Intl.NumberFormat('ru-RU', {minimumFractionDigits: 0, maximumFractionDigits: 2}),
+        [],
+    )
+
+    const {
+        data: totalPaidRaw,
+        isLoading: isTotalLoading,
+        isFetching: isTotalFetching,
+    } = useQuery({
+        queryKey: ['client-total-paid', id, selectedYear],
+        enabled: !!id,
+        queryFn: async () => {
+            if (!id) return 0
+            const params: VisitQueryParams = {
+                client_id: id,
+                status: 'PAID' as VisitStatusEnum,
+                limit: 1,
+                offset: 0,
+            }
+
+            if (selectedYear !== 'all') {
+                const start = dayjs().year(selectedYear).startOf('year').toISOString()
+                const end = dayjs().year(selectedYear).endOf('year').toISOString()
+                params.start_date = start
+                params.end_date = end
+            }
+
+            const res = await fetchVisits(params)
+            return res.total_cost ?? 0
+        },
+    })
+
+    const handleTotalsChange = useCallback(() => {
+        if (!id) return
+        queryClient.invalidateQueries({queryKey: ['client-total-paid', id]})
+    }, [queryClient, id])
+
+    const totalPaid = totalPaidRaw ?? 0
+    const totalPaidDisplay = (isTotalLoading && totalPaidRaw === undefined)
+        ? 'Загрузка…'
+        : `${currencyFormatter.format(totalPaid)} ₽${isTotalFetching && !isTotalLoading ? ' ⋯' : ''}`
+
+    if (!id) return <div>Некорректный id</div>
 
     return (
         <div style={{ maxWidth: 1200, margin: '0 auto' }}>
@@ -46,10 +106,29 @@ export default function ClientProfilePage() {
                 )}
             </Card>
 
+            <Card style={{ marginBottom: 16 }}>
+                <Space direction="vertical" size="small">
+                    <Typography.Text type="secondary">Оплачено</Typography.Text>
+                    <Typography.Title level={4} style={{ margin: 0 }}>
+                        {totalPaidDisplay}
+                    </Typography.Title>
+                    <Space size="small" wrap align="center">
+                        <Typography.Text type="secondary">Период:</Typography.Text>
+                        <Select
+                            value={selectedYear}
+                            options={yearOptions}
+                            onChange={(value) => setSelectedYear(value as YearFilterValue)}
+                            style={{ minWidth: 160 }}
+                        />
+                    </Space>
+                </Space>
+            </Card>
+
             <Typography.Title level={4} style={{ marginTop: 0 }}>Посещения</Typography.Title>
 
             <VisitsManager
                 context={{ clientId: id }}
+                onTotalsChange={handleTotalsChange}
                 // можно тонко настраивать отображение:
                 show={{
                     client: false,        // на странице пациента столбец «Пациент» не нужен


### PR DESCRIPTION
## Summary
- keep ClientProfilePage hooks unconditional while guarding the invalid id case
- propagate visit mutations to invalidate the client total paid query so the summary refreshes

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910a4bd8a788326abf3677681e4758b)