### PR TITLE
Add Russian formatting for phone and date inputs

### DIFF
--- a/web/src/components/EntityManager.tsx
+++ b/web/src/components/EntityManager.tsx
@@ -1,5 +1,6 @@
 // src/components/EntityManager.tsx
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button, Form, Input, Modal, Space, Table, message } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -93,7 +94,7 @@ export default function EntityManager<
                 <Button onClick={() => {
                     setEditing(row); setOpen(true)
                     // setFieldsValue ожидает RecursivePartial<TFormValues>
-                    form.setFieldsValue(toForm(row))
+                    form.setFieldsValue(toForm(row) as any)
                 }}>
                     <Pencil size={16} className="text-blue-600" />
                 </Button>

--- a/web/src/components/EntityManager.tsx
+++ b/web/src/components/EntityManager.tsx
@@ -33,6 +33,7 @@ type EntityManagerProps<
     toUpdate: (v: TFormValues) => TUpdate
     searchPlaceholder?: string
     createButtonText?: string
+    initialValues?: RecursivePartial<TFormValues>
 };
 
 export default function EntityManager<
@@ -43,7 +44,7 @@ export default function EntityManager<
 >(props: EntityManagerProps<TItem, TCreate, TUpdate, TFormValues>) {
     const {
         title, queryKey, fetchList, createItem, updateItem,
-        columns, renderForm, toForm, toCreate, toUpdate,
+        columns, renderForm, toForm, toCreate, toUpdate, initialValues,
         searchPlaceholder = 'Поиск…', createButtonText = 'Создать',
     } = props
 
@@ -94,7 +95,7 @@ export default function EntityManager<
                 <Button onClick={() => {
                     setEditing(row); setOpen(true)
                     // setFieldsValue ожидает RecursivePartial<TFormValues>
-                    form.setFieldsValue(toForm(row) as any)
+                    form.setFieldsValue(toForm(row) as Partial<TFormValues>)
                 }}>
                     <Pencil size={16} className="text-blue-600" />
                 </Button>
@@ -120,7 +121,15 @@ export default function EntityManager<
                     onChange={(e) => setSearch(e.target.value)}
                     allowClear
                 />
-                <Button type="primary" onClick={() => { setEditing(null); setOpen(true); form.resetFields() }}>
+                <Button
+                    type="primary"
+                    onClick={() => {
+                        setEditing(null)
+                        setOpen(true)
+                        form.resetFields()
+                        if (initialValues) form.setFieldsValue(initialValues as Partial<TFormValues>)
+                    }}
+                >
                     {createButtonText}
                 </Button>
             </Space>
@@ -136,7 +145,7 @@ export default function EntityManager<
                 cancelText="Отмена"
                 confirmLoading={createMut.isPending || updateMut.isPending}
             >
-                <Form form={form} layout="vertical">
+                <Form form={form} layout="vertical" initialValues={initialValues}>
                     {renderForm(form, editing)}
                 </Form>
             </Modal>

--- a/web/src/components/visits/VisitsManager.tsx
+++ b/web/src/components/visits/VisitsManager.tsx
@@ -37,6 +37,7 @@ import {PRINT_HEADERS} from './printConsts'
 
 import {useEffect, useRef} from 'react'
 import VisitsPrintSheet from "./VisitsPrintSheet.tsx";
+import { formatPhoneNumber } from '../../lib/phone'
 
 type DoctorMini = { id: string; full_name: string; speciality: string }
 type ClientMini = { id: string; full_name: string; phone_number?: string | null; date_of_birth?: string | null }
@@ -448,7 +449,8 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
                     const a = dayjs().diff(birth, 'year')
                     return `${a} лет`
                 })() : undefined
-                return [c.phone_number || undefined, dob && `рожд. ${dob}`, age].filter(Boolean).join(' · ')
+                const phone = formatPhoneNumber(c.phone_number)
+                return [phone || undefined, dob && `рожд. ${dob}`, age].filter(Boolean).join(' · ')
             })() : ''
 
     const printNote = (() => {
@@ -580,7 +582,7 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
                         <EntityLink kind="clients" id={v.client_id} label={v.client_name}/>
                         {v.client_phone_number && (
                             <span style={{color: '#8c8c8c', fontSize: 12}}>
-                                {v.client_phone_number}
+                                {formatPhoneNumber(v.client_phone_number)}
                             </span>
                         )}
                     </div>

--- a/web/src/lib/phone.ts
+++ b/web/src/lib/phone.ts
@@ -1,0 +1,32 @@
+const cleanDigits = (value: string): string => value.replace(/\D/g, '')
+
+const ensureSevenPrefix = (digits: string): string => {
+    if (!digits) return ''
+    if (digits.startsWith('8')) return `7${digits.slice(1)}`
+    if (digits.startsWith('7')) return digits
+    return `7${digits}`
+}
+
+export function formatPhoneNumber(value?: string | null): string {
+    const normalized = ensureSevenPrefix(cleanDigits(value ?? '')).slice(0, 11)
+    if (!normalized) return ''
+
+    let result = '+7'
+
+    if (normalized.length > 1) {
+        result += ' (' + normalized.slice(1, 4)
+        if (normalized.length >= 4) result += ')'
+    }
+
+    if (normalized.length > 4) result += ' ' + normalized.slice(4, 7)
+    if (normalized.length > 7) result += '-' + normalized.slice(7, 9)
+    if (normalized.length > 9) result += '-' + normalized.slice(9, 11)
+
+    return result
+}
+
+export function normalizePhoneNumber(value?: string | null): string | undefined {
+    const normalized = ensureSevenPrefix(cleanDigits(value ?? ''))
+    if (!normalized) return undefined
+    return `+${normalized.slice(0, 11)}`
+}

--- a/web/src/lib/phone.ts
+++ b/web/src/lib/phone.ts
@@ -1,15 +1,23 @@
 const cleanDigits = (value: string): string => value.replace(/\D/g, '')
 
 const ensureSevenPrefix = (digits: string): string => {
-    if (!digits) return ''
+    if (!digits) return '7'
     if (digits.startsWith('8')) return `7${digits.slice(1)}`
     if (digits.startsWith('7')) return digits
     return `7${digits}`
 }
 
+const applyPhoneMask = (digits: string): string => {
+    const padded = (digits + '__________').slice(0, 10)
+
+    return `+7 (${padded.slice(0, 3)}) ${padded.slice(3, 6)}-${padded.slice(6, 8)}-${padded.slice(8, 10)}`
+}
+
 export function formatPhoneNumber(value?: string | null): string {
-    const normalized = ensureSevenPrefix(cleanDigits(value ?? '')).slice(0, 11)
-    if (!normalized) return ''
+    const rawDigits = cleanDigits(value ?? '')
+    if (!rawDigits) return ''
+
+    const normalized = ensureSevenPrefix(rawDigits).slice(0, 11)
 
     let result = '+7'
 
@@ -25,8 +33,17 @@ export function formatPhoneNumber(value?: string | null): string {
     return result
 }
 
+export function formatPhoneInput(value?: string | null): string {
+    const normalized = ensureSevenPrefix(cleanDigits(value ?? '')).slice(0, 11)
+    const digitsWithoutPrefix = normalized.slice(1)
+
+    return applyPhoneMask(digitsWithoutPrefix)
+}
+
 export function normalizePhoneNumber(value?: string | null): string | undefined {
-    const normalized = ensureSevenPrefix(cleanDigits(value ?? ''))
-    if (!normalized) return undefined
+    const digits = cleanDigits(value ?? '')
+    if (!digits) return undefined
+
+    const normalized = ensureSevenPrefix(digits)
     return `+${normalized.slice(0, 11)}`
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { ConfigProvider } from 'antd'
+import ruRU from 'antd/locale/ru_RU'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ru'
 import App from './App'
 import DoctorsPage from './pages/DoctorsPage'
 import 'antd/dist/reset.css'
@@ -10,6 +14,8 @@ import VisitsPage from "./pages/VisitsPage.tsx";
 import ClientProfilePage from "./pages/ClientProfilePage.tsx";
 import DoctorProfilePage from "./pages/DoctorProfilePage.tsx";
 import VisitDetailPage from "./pages/VisitDetailPage.tsx";
+
+dayjs.locale('ru')
 
 const qc = new QueryClient()
 
@@ -30,8 +36,10 @@ const router = createBrowserRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <QueryClientProvider client={qc}>
-            <RouterProvider router={router} />
-        </QueryClientProvider>
+        <ConfigProvider locale={ruRU}>
+            <QueryClientProvider client={qc}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
+        </ConfigProvider>
     </React.StrictMode>,
 )

--- a/web/src/pages/ClientProfilePage.tsx
+++ b/web/src/pages/ClientProfilePage.tsx
@@ -7,6 +7,7 @@ import type { ClientResponse, VisitStatusEnum } from '../api'
 import { Button, Card, Col, Row, Select, Skeleton, Space, Typography } from 'antd'
 import { fetchVisits, type VisitQueryParams } from '../api/visits'
 import VisitsManager from '../components/visits/VisitsManager'
+import { formatPhoneNumber } from '../lib/phone'
 
 async function fetchClient(id: string): Promise<ClientResponse> {
     const res = await api.get<ClientResponse>(`/clients/${id}`)
@@ -85,7 +86,7 @@ export default function ClientProfilePage() {
         <div style={{ maxWidth: 1200, margin: '0 auto' }}>
             <Row gutter={[16, 16]} align="middle" style={{ marginBottom: 12 }}>
                 <Col flex="none">
-                    <Button onClick={() => navigate('/clients')}>← К списку</Button>
+                    <Button onClick={() => navigate(-1)}>← Назад</Button>
                 </Col>
                 <Col flex="auto">
                     <Typography.Title level={3} style={{ margin: 0 }}>
@@ -100,8 +101,10 @@ export default function ClientProfilePage() {
                 ) : (
                     <Row gutter={[16, 8]}>
                         <Col xs={24} md={8}><b>ФИО:</b> {client?.full_name}</Col>
-                        <Col xs={24} md={8}><b>Телефон:</b> {client?.phone_number}</Col>
-                        <Col xs={24} md={8}><b>Дата рождения:</b> {client?.date_of_birth}</Col>
+                        <Col xs={24} md={8}><b>Телефон:</b> {formatPhoneNumber(client?.phone_number)}</Col>
+                        <Col xs={24} md={8}>
+                            <b>Дата рождения:</b> {client?.date_of_birth ? dayjs(client.date_of_birth).format('DD.MM.YYYY') : '—'}
+                        </Col>
                     </Row>
                 )}
             </Card>

--- a/web/src/pages/ClientsPage.tsx
+++ b/web/src/pages/ClientsPage.tsx
@@ -5,6 +5,7 @@ import EntityManager from '../components/EntityManager'
 import EntityLink from '../components/EntityLink'
 import { api } from '../lib/api'
 import type { ClientCreateRequest, ClientResponse, ClientUpdateRequest } from '../api'
+import { formatPhoneNumber, normalizePhoneNumber } from '../lib/phone'
 
 /** UI-форма пациентов: дата — Dayjs|null */
 type ClientForm = {
@@ -34,7 +35,11 @@ const columns: ColumnsType<ClientResponse> = [
             <EntityLink kind="clients" id={row.id} label={row.full_name} />
         ),
     },
-    { title: 'Телефон', dataIndex: 'phone_number' },
+    {
+        title: 'Телефон',
+        dataIndex: 'phone_number',
+        render: (value: string | null) => formatPhoneNumber(value),
+    },
     {
         title: 'Дата рождения',
         dataIndex: 'date_of_birth',
@@ -62,27 +67,32 @@ export default function ClientsPage() {
                         <Form.Item name="full_name" label="ФИО" rules={[{ required: true, message: 'Укажите ФИО' }]}>
                             <Input />
                         </Form.Item>
-                        <Form.Item name="phone_number" label="Телефон" rules={[{ required: true, message: 'Укажите телефон' }]}>
-                            <Input />
+                        <Form.Item
+                            name="phone_number"
+                            label="Телефон"
+                            rules={[{ required: true, message: 'Укажите телефон' }]}
+                            getValueFromEvent={(e) => formatPhoneNumber(e.target.value)}
+                        >
+                            <Input inputMode="tel" placeholder="+7 (___) ___-__-__" />
                         </Form.Item>
                         <Form.Item name="date_of_birth" label="Дата рождения" rules={[{ required: true, message: 'Укажите дату рождения' }]}>
-                            <DatePicker style={{ width: '100%' }} format={"DD.MM.YYYY"} />
+                            <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
                         </Form.Item>
                     </>
                 )}
                 toForm={(item) => ({
                     full_name: item.full_name,
-                    phone_number: item.phone_number,
+                    phone_number: formatPhoneNumber(item.phone_number),
                     date_of_birth: item.date_of_birth ? dayjs(item.date_of_birth) : null,
                 })}
                 toCreate={(v) => ({
                     full_name: v.full_name!,
-                    phone_number: v.phone_number!,
+                    phone_number: normalizePhoneNumber(v.phone_number)!,
                     date_of_birth: v.date_of_birth!.format('YYYY-MM-DD'),
                 })}
                 toUpdate={(v) => ({
                     full_name: v.full_name,
-                    phone_number: v.phone_number,
+                    phone_number: normalizePhoneNumber(v.phone_number),
                     date_of_birth: v.date_of_birth ? v.date_of_birth.format('YYYY-MM-DD') : undefined,
                 })}
             />

--- a/web/src/pages/ClientsPage.tsx
+++ b/web/src/pages/ClientsPage.tsx
@@ -62,6 +62,7 @@ export default function ClientsPage() {
                 columns={columns}
                 searchPlaceholder="Поиск по ФИО/телефону"
                 createButtonText="Новый пациент"
+                initialValues={{ phone_number: formatPhoneInput('') }}
                 renderForm={() => (
                     <>
                         <Form.Item name="full_name" label="ФИО" rules={[{ required: true, message: 'Укажите ФИО' }]}>

--- a/web/src/pages/ClientsPage.tsx
+++ b/web/src/pages/ClientsPage.tsx
@@ -5,7 +5,7 @@ import EntityManager from '../components/EntityManager'
 import EntityLink from '../components/EntityLink'
 import { api } from '../lib/api'
 import type { ClientCreateRequest, ClientResponse, ClientUpdateRequest } from '../api'
-import { formatPhoneNumber, normalizePhoneNumber } from '../lib/phone'
+import { formatPhoneInput, formatPhoneNumber, normalizePhoneNumber } from '../lib/phone'
 
 /** UI-форма пациентов: дата — Dayjs|null */
 type ClientForm = {
@@ -71,7 +71,7 @@ export default function ClientsPage() {
                             name="phone_number"
                             label="Телефон"
                             rules={[{ required: true, message: 'Укажите телефон' }]}
-                            getValueFromEvent={(e) => formatPhoneNumber(e.target.value)}
+                            getValueFromEvent={(e) => formatPhoneInput(e.target.value)}
                         >
                             <Input inputMode="tel" placeholder="+7 (___) ___-__-__" />
                         </Form.Item>
@@ -82,7 +82,7 @@ export default function ClientsPage() {
                 )}
                 toForm={(item) => ({
                     full_name: item.full_name,
-                    phone_number: formatPhoneNumber(item.phone_number),
+                    phone_number: formatPhoneInput(item.phone_number),
                     date_of_birth: item.date_of_birth ? dayjs(item.date_of_birth) : null,
                 })}
                 toCreate={(v) => ({

--- a/web/src/pages/DoctorProfilePage.tsx
+++ b/web/src/pages/DoctorProfilePage.tsx
@@ -25,7 +25,7 @@ export default function DoctorProfilePage() {
         <div style={{ maxWidth: 1200, margin: '0 auto' }}>
             <Row gutter={[16, 16]} align="middle" style={{ marginBottom: 12 }}>
                 <Col flex="none">
-                    <Button onClick={() => navigate('/doctors')}>← К списку</Button>
+                    <Button onClick={() => navigate(-1)}>← Назад</Button>
                 </Col>
                 <Col flex="auto">
                     <Typography.Title level={3} style={{ margin: 0 }}>

--- a/web/src/pages/VisitDetailPage.tsx
+++ b/web/src/pages/VisitDetailPage.tsx
@@ -237,7 +237,7 @@ export default function VisitDetailPage() {
 
                     <Col xs={24} md={8}>
                         <Form.Item name="date" label="Дата" rules={[{required: true, message: 'Укажите дату'}]}>
-                            <DatePicker style={{width: '100%'}}/>
+                            <DatePicker style={{width: '100%'}} format="DD.MM.YYYY" />
                         </Form.Item>
                     </Col>
                     <Col xs={24} md={8}>


### PR DESCRIPTION
## Summary
- configure Russian locale for the UI and date pickers and ensure visit forms show DD.MM.YYYY
- add phone formatting/normalization helpers and apply them across patient and visit views
- update patient/doctor navigation buttons to go back to the previous page

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f24a3aeb4832685358ef2b94d8828)