### PR TITLE
Allow optional client birth date and improve phone input

### DIFF
--- a/app/schemas/client.py
+++ b/app/schemas/client.py
@@ -5,12 +5,12 @@ from app.schemas.human import HumanCreateRequest, HumanResponse, HumanUpdateRequ
 
 class ClientCreateRequest(HumanCreateRequest):
     phone_number: str
-    date_of_birth: date
+    date_of_birth: date | None = None
 
 
 class ClientResponse(HumanResponse):
     phone_number: str
-    date_of_birth: date
+    date_of_birth: date | None = None
 
 
 class ClientUpdateRequest(HumanUpdateRequest):

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -167,7 +167,7 @@ export interface components {
              * Date Of Birth
              * Format: date
              */
-            date_of_birth: string;
+            date_of_birth?: string | null;
         };
         /** ClientResponse */
         ClientResponse: {
@@ -200,7 +200,7 @@ export interface components {
              * Date Of Birth
              * Format: date
              */
-            date_of_birth: string;
+            date_of_birth?: string | null;
         };
         /** ClientUpdateRequest */
         ClientUpdateRequest: {

--- a/web/src/lib/phone.ts
+++ b/web/src/lib/phone.ts
@@ -34,10 +34,24 @@ export function formatPhoneNumber(value?: string | null): string {
 }
 
 export function formatPhoneInput(value?: string | null): string {
-    const normalized = ensureSevenPrefix(cleanDigits(value ?? '')).slice(0, 11)
-    const digitsWithoutPrefix = normalized.slice(1)
+    const digits = cleanDigits(value ?? '')
+    if (!digits) return ''
 
-    return applyPhoneMask(digitsWithoutPrefix)
+    const normalized = ensureSevenPrefix(digits).slice(0, 11)
+
+    let result = '+7'
+    const rest = normalized.slice(1)
+
+    if (rest.length > 0) {
+        result += ' (' + rest.slice(0, 3)
+        if (rest.length >= 3) result += ')'
+    }
+
+    if (rest.length > 3) result += ' ' + rest.slice(3, 6)
+    if (rest.length > 6) result += '-' + rest.slice(6, 8)
+    if (rest.length > 8) result += '-' + rest.slice(8, 10)
+
+    return result
 }
 
 export function normalizePhoneNumber(value?: string | null): string | undefined {

--- a/web/src/pages/ClientsPage.tsx
+++ b/web/src/pages/ClientsPage.tsx
@@ -76,7 +76,7 @@ export default function ClientsPage() {
                         >
                             <Input inputMode="tel" placeholder="+7 (___) ___-__-__" />
                         </Form.Item>
-                        <Form.Item name="date_of_birth" label="Дата рождения" rules={[{ required: true, message: 'Укажите дату рождения' }]}>
+                        <Form.Item name="date_of_birth" label="Дата рождения">
                             <DatePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
                         </Form.Item>
                     </>
@@ -89,7 +89,7 @@ export default function ClientsPage() {
                 toCreate={(v) => ({
                     full_name: v.full_name!,
                     phone_number: normalizePhoneNumber(v.phone_number)!,
-                    date_of_birth: v.date_of_birth!.format('YYYY-MM-DD'),
+                    date_of_birth: v.date_of_birth ? v.date_of_birth.format('YYYY-MM-DD') : undefined,
                 })}
                 toUpdate={(v) => ({
                     full_name: v.full_name,


### PR DESCRIPTION
## Summary
- improve phone input formatting on the clients page so it supports normal backspacing
- make client birth date optional across backend schema, API types, and frontend form handling
- send date of birth only when provided during client creation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f45c688e483269a42058262b6b5c9)