### PR TITLE
Add schedule editing and deletion controls

### DIFF
--- a/web/src/api/schedules.ts
+++ b/web/src/api/schedules.ts
@@ -1,0 +1,50 @@
+import {api} from '../lib/api'
+
+export type ScheduleCreateRequest = {
+    doctor_id: string
+    date: string
+    start_time: string
+    end_time: string
+    duration: string
+}
+
+export type ScheduleResponse = {
+    id: string
+    dt_created: string
+    dt_updated: string
+    doctor_id: string
+    date: string
+    start_time: string
+    end_time: string
+    duration: string
+}
+
+export type ScheduleUpdateRequest = {
+    start_time?: string
+    end_time?: string
+    duration?: string
+}
+
+export async function fetchSchedule(date: string, doctorId: string): Promise<ScheduleResponse> {
+    const res = await api.get<ScheduleResponse>(`/schedules/${date}/${doctorId}`)
+    return res.data
+}
+
+export async function createSchedule(body: ScheduleCreateRequest): Promise<ScheduleResponse> {
+    const res = await api.post<ScheduleResponse>('/schedules', body)
+    return res.data
+}
+
+export async function updateSchedule(
+    date: string,
+    doctorId: string,
+    body: ScheduleUpdateRequest,
+): Promise<ScheduleResponse> {
+    const res = await api.patch<ScheduleResponse>(`/schedules/${date}/${doctorId}`, body)
+    return res.data
+}
+
+export async function deleteSchedule(date: string, doctorId: string): Promise<void> {
+    await api.delete(`/schedules/${date}/${doctorId}`)
+}
+

--- a/web/src/components/EntityManager.tsx
+++ b/web/src/components/EntityManager.tsx
@@ -5,15 +5,15 @@ import { Button, Form, Input, Modal, Space, Table, message } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { FormInstance } from 'antd'
-import { getErrorMessage } from '../lib/errors'
-import {Pencil} from "lucide-react";
-
-type WithId = { id: string }
 
 // антовский setFieldsValue ждёт recursive partial
 export type RecursivePartial<T> = {
     [K in keyof T]?: T[K] extends object ? RecursivePartial<T[K]> : T[K]
 }
+import { getErrorMessage } from '../lib/errors'
+import {Pencil} from "lucide-react";
+
+type WithId = { id: string }
 
 type EntityManagerProps<
     TItem extends WithId,
@@ -95,7 +95,7 @@ export default function EntityManager<
                 <Button onClick={() => {
                     setEditing(row); setOpen(true)
                     // setFieldsValue ожидает RecursivePartial<TFormValues>
-                    form.setFieldsValue(toForm(row) as Partial<TFormValues>)
+                    form.setFieldsValue(toForm(row) as Parameters<typeof form.setFieldsValue>[0])
                 }}>
                     <Pencil size={16} className="text-blue-600" />
                 </Button>
@@ -127,7 +127,7 @@ export default function EntityManager<
                         setEditing(null)
                         setOpen(true)
                         form.resetFields()
-                        if (initialValues) form.setFieldsValue(initialValues as Partial<TFormValues>)
+                        if (initialValues) form.setFieldsValue(initialValues as Parameters<typeof form.setFieldsValue>[0])
                     }}
                 >
                     {createButtonText}

--- a/web/src/components/visits/VisitsManager.tsx
+++ b/web/src/components/visits/VisitsManager.tsx
@@ -13,13 +13,23 @@ import {
     Popconfirm,
     Tooltip,
     Dropdown,
-    Typography
+    Typography,
+    Switch
 } from 'antd'
 import type {ColumnsType} from 'antd/es/table'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import dayjs, {Dayjs} from 'dayjs'
 import {api} from '../../lib/api'
 import type {VisitCreateRequest, VisitResponse, VisitStatusEnum, VisitUpdateRequest} from '../../api'
+import {
+    createSchedule,
+    deleteSchedule,
+    fetchSchedule,
+    updateSchedule,
+    type ScheduleCreateRequest,
+    type ScheduleResponse,
+    type ScheduleUpdateRequest,
+} from '../../api/schedules'
 import {fetchVisits, type VisitPageResponse, type VisitQueryParams} from '../../api/visits'
 import {getErrorMessage} from '../../lib/errors'
 import EntitySelect from '../EntitySelect'
@@ -27,6 +37,7 @@ import {Info, Pencil, Trash2} from 'lucide-react'
 import {useNavigate, useLocation} from 'react-router-dom'
 import EntityLink from '../EntityLink'
 import {TimePicker} from 'antd' // <- используем нормальный тайм-пикер
+import axios from 'axios'
 
 import {Modal as AntModal, Checkbox} from 'antd'
 import type {CheckboxChangeEvent} from 'antd/es/checkbox'
@@ -75,6 +86,12 @@ type VisitFormValues = {
     procedure?: string
     cabinet?: string
     cost?: number
+}
+
+type ScheduleFormValues = {
+    start_time?: Dayjs
+    end_time?: Dayjs
+    duration?: number
 }
 
 type ShowColumns = Partial<{
@@ -218,6 +235,49 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         return {h: Number(m[1]), m: Number(m[2])}
     }, [])
 
+    const parseHHMMSS = useCallback((s: string): { h: number; m: number; s: number } => {
+        const m = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/.exec((s ?? '').trim())
+        if (!m) return {h: 0, m: 0, s: 0}
+        return {h: Number(m[1]), m: Number(m[2]), s: m[3] ? Number(m[3]) : 0}
+    }, [])
+
+    const parseDurationMinutes = useCallback((s: string): number => {
+        const trimmed = (s ?? '').trim()
+
+        // Поддерживаем ISO-8601 длительности, например "PT10M", "P1DT2H30M"
+        const isoMatch = /^P(?:(\d+)D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(trimmed)
+        if (isoMatch) {
+            const days = Number(isoMatch[1] ?? 0)
+            const hours = Number(isoMatch[2] ?? 0)
+            const minutes = Number(isoMatch[3] ?? 0)
+            const seconds = Number(isoMatch[4] ?? 0)
+            return days * 24 * 60 + hours * 60 + minutes + Math.floor(seconds / 60)
+        }
+
+        // Поддерживаем формат "HH:MM:SS" и варианты вида "1 day, 02:00:00"
+        const match = /(?:(\d+)\s+day[s]?,\s*)?(\d{1,2}):(\d{2})(?::(\d{2}))?/.exec(trimmed)
+        if (!match) return 0
+        const days = Number(match[1] ?? 0)
+        const hours = Number(match[2] ?? 0)
+        const minutes = Number(match[3] ?? 0)
+        const seconds = Number(match[4] ?? 0)
+        return days * 24 * 60 + hours * 60 + minutes + Math.floor(seconds / 60)
+    }, [])
+
+    const toDurationString = useCallback((minutes: number): string => {
+        const safeMinutes = Math.max(0, Math.floor(minutes))
+        const days = Math.floor(safeMinutes / (24 * 60))
+        const remainderAfterDays = safeMinutes % (24 * 60)
+        const hrs = Math.floor(remainderAfterDays / 60)
+        const mins = remainderAfterDays % 60
+
+        const parts = [] as string[]
+        if (hrs) parts.push(`${hrs}H`)
+        if (mins || (!hrs && !days)) parts.push(`${mins}M`)
+
+        return `P${days ? `${days}D` : ''}T${parts.join('')}`
+    }, [])
+
     function disabledHoursForWorkday() {
         const arr: number[] = []
         for (let h = 0; h < 24; h++) {
@@ -233,10 +293,21 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         start_date: string
         end_date: string
     }
-    type RowData = VisitResponse | GapRow
+    type SlotRow = {
+        __slot: true
+        id: string
+        start_date: string
+        end_date: string
+        durationMinutes: number
+    }
+    type RowData = VisitResponse | GapRow | SlotRow
 
     function isGap(row: unknown): row is GapRow {
         return typeof row === 'object' && row !== null && '__gap' in row && (row as GapRow).__gap
+    }
+
+    function isSlot(row: unknown): row is SlotRow {
+        return typeof row === 'object' && row !== null && '__slot' in row && (row as SlotRow).__slot
     }
 
 
@@ -288,6 +359,73 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         return rows
     }, [parseHHMM])
 
+    const buildScheduleRows = useCallback((day: Dayjs, visits: VisitResponse[], schedule: ScheduleResponse): RowData[] => {
+        const durationMinutes = parseDurationMinutes(schedule.duration)
+        if (!durationMinutes || durationMinutes <= 0) return visits
+
+        const {h: startH, m: startM, s: startS} = parseHHMMSS(schedule.start_time)
+        const {h: endH, m: endM, s: endS} = parseHHMMSS(schedule.end_time)
+
+        const dayStart = day.startOf('day').hour(startH).minute(startM).second(startS).millisecond(0)
+        const dayEnd = day.startOf('day').hour(endH).minute(endM).second(endS).millisecond(0)
+
+        if (!dayEnd.isAfter(dayStart)) return visits
+
+        const sortedVisits = [...visits].sort((a, b) =>
+            dayjs(a.start_date).valueOf() - dayjs(b.start_date).valueOf()
+        )
+
+        const getVisitRange = (visit: VisitResponse) => {
+            const start = dayjs(visit.start_date).millisecond(0)
+            const end = visit.end_date ? dayjs(visit.end_date).millisecond(0) : start
+            return {start, end}
+        }
+
+        const rows: RowData[] = []
+        let cursor = dayStart
+        let visitIdx = 0
+        let guard = 0
+
+        while (cursor.isBefore(dayEnd) && guard < 10_000) {
+            const slotEnd = cursor.add(durationMinutes, 'minute')
+            let overlappingVisit: VisitResponse | undefined
+
+            while (visitIdx < sortedVisits.length) {
+                const visit = sortedVisits[visitIdx]
+                const {start, end} = getVisitRange(visit)
+
+                if (end.isBefore(cursor) || end.isSame(cursor)) {
+                    visitIdx += 1
+                    continue
+                }
+
+                if (start.isBefore(slotEnd) && end.isAfter(cursor)) {
+                    overlappingVisit = visit
+                }
+
+                break
+            }
+
+            if (overlappingVisit) {
+                rows.push(overlappingVisit)
+                cursor = getVisitRange(overlappingVisit).end
+            } else {
+                rows.push({
+                    __slot: true,
+                    id: `slot-${cursor.toISOString()}`,
+                    start_date: cursor.toISOString(),
+                    end_date: slotEnd.toISOString(),
+                    durationMinutes,
+                })
+                cursor = slotEnd
+            }
+
+            guard += 1
+        }
+
+        return rows
+    }, [parseDurationMinutes, parseHHMMSS])
+
     type EditableField = 'procedure' | 'cost'
 
     const [editingCell, setEditingCell] = useState<{ id: string; field: EditableField } | null>(null)
@@ -338,6 +476,8 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
                 : ['date', 'time', 'client', 'doctor', 'procedure', 'status', 'cost'] // общий
     )
 
+    const [ignoreSchedule, setIgnoreSchedule] = useState(false)
+
     const [clientsMap, setClientsMap] = useState<Record<string, ClientMini>>({})
     const [doctorsMap, setDoctorsMap] = useState<Record<string, DoctorMini>>({})
 
@@ -367,17 +507,49 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         return p
     }, [isDoctorDayMode, clientId, doctorId, status, cabinet, procedure, day, range, pageSize, page])
 
+    const scheduleDate = useMemo(() => day?.format('YYYY-MM-DD'), [day])
+
+    const {
+        data: scheduleData,
+        isFetching: isScheduleLoading,
+        isError: isScheduleError,
+    } = useQuery<ScheduleResponse | null>({
+        queryKey: ['schedule', scheduleDate, effDoctorId],
+        enabled: isDoctorDayMode && !!scheduleDate && !!effDoctorId,
+        queryFn: async () => {
+            try {
+                return await fetchSchedule(scheduleDate!, effDoctorId!)
+            } catch (err: unknown) {
+                if (axios.isAxiosError(err) && err.response?.status === 404) return null
+                throw err
+            }
+        },
+        retry: false,
+    })
+
     const {data, isLoading} = useQuery<VisitPageResponse>({
         queryKey: ['visits', params],
         queryFn: () => fetchVisits(params),
     })
 
+    const scheduleTableData: RowData[] | null = useMemo(() => {
+        if (!isDoctorDayMode || !scheduleData || !day) return null
+        return buildScheduleRows(day, data?.items ?? [], scheduleData)
+    }, [isDoctorDayMode, scheduleData, day, data?.items, buildScheduleRows])
+
+    useEffect(() => {
+        if (isScheduleError) {
+            message.warning('Не удалось загрузить разлиновку, показываем обычный список')
+        }
+    }, [isScheduleError])
+
     const tableData: RowData[] = useMemo(() => {
         const items = data?.items ?? []
+        if (scheduleTableData && !ignoreSchedule) return scheduleTableData
         if (!isDayMode) return items as RowData[]
         if (!day) return []
         return buildDayRows(day, items, MIN_TIME, MAX_TIME)
-    }, [isDayMode, data, day, buildDayRows, MIN_TIME, MAX_TIME])
+    }, [isDayMode, data, day, buildDayRows, MIN_TIME, MAX_TIME, scheduleTableData, ignoreSchedule])
 
     const totalCostValue = data?.total_cost ?? 0
     const totalCostDisplay = isLoading && !data
@@ -475,6 +647,9 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
     const [open, setOpen] = useState(false)
     const [editing, setEditing] = useState<VisitResponse | null>(null)
     const [form] = Form.useForm<VisitFormValues>()
+    const [scheduleForm] = Form.useForm<ScheduleFormValues>()
+    const [scheduleModalOpen, setScheduleModalOpen] = useState(false)
+    const [scheduleModalMode, setScheduleModalMode] = useState<'create' | 'update'>('create')
 
     const createMut = useMutation({
         mutationFn: (b: VisitCreateRequest) => createVisit(b),
@@ -522,16 +697,47 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         onError: (err: unknown) => message.error(getErrorMessage(err)),
     })
 
+    const createScheduleMut = useMutation({
+        mutationFn: (b: ScheduleCreateRequest) => createSchedule(b),
+        onSuccess: () => {
+            message.success('Разлиновка сохранена')
+            qc.invalidateQueries({queryKey: ['schedule']})
+            setScheduleModalOpen(false)
+        },
+        onError: (err: unknown) => message.error(getErrorMessage(err)),
+    })
+
+    const updateScheduleMut = useMutation({
+        mutationFn: ({date, doctorId, body}: { date: string; doctorId: string; body: ScheduleUpdateRequest }) =>
+            updateSchedule(date, doctorId, body),
+        onSuccess: () => {
+            message.success('Разлиновка обновлена')
+            qc.invalidateQueries({queryKey: ['schedule']})
+            setScheduleModalOpen(false)
+        },
+        onError: (err: unknown) => message.error(getErrorMessage(err)),
+    })
+
+    const deleteScheduleMut = useMutation({
+        mutationFn: ({date, doctorId}: { date: string; doctorId: string }) => deleteSchedule(date, doctorId),
+        onSuccess: () => {
+            message.success('Разлиновка удалена')
+            qc.invalidateQueries({queryKey: ['schedule']})
+            setIgnoreSchedule(false)
+        },
+        onError: (err: unknown) => message.error(getErrorMessage(err)),
+    })
+
     // -------- Колонки --------
     let totalCols = 0
-    const columns: ColumnsType<VisitResponse | GapRow> = []
+    const columns: ColumnsType<RowData> = []
     if (!isDayMode && show?.date !== false) {
         columns.push({
             title: 'Дата',
             width: 110,
             dataIndex: 'start_date',
-            render: (iso: string, row: VisitResponse | GapRow) =>
-                isGap(row)
+            render: (iso: string, row: RowData) =>
+                isGap(row) || isSlot(row)
                     ? {children: null, props: {colSpan: 0}}
                     : dayjs(iso).format('DD.MM.YYYY'),
         })
@@ -540,7 +746,7 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         title: 'Время',
         key: 'time',
         width: 140,
-        render: (row: VisitResponse | GapRow) => {
+        render: (row: RowData) => {
             const start = dayjs(row.start_date).format('HH:mm')
             const end = row.end_date ? dayjs(row.end_date).format('HH:mm') : ''
             const label = end ? `${start}–${end}` : start
@@ -571,9 +777,16 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         columns.push({
             title: 'Пациент',
             key: 'client',
-            render: (_: unknown, row: VisitResponse | GapRow) => {
+            render: (_: unknown, row: RowData) => {
                 if (isGap(row)) {
                     return {children: null, props: {colSpan: 0}}
+                }
+                if (isSlot(row)) {
+                    return (
+                        <Button type="dashed" size="small" onClick={() => openSlotForm(row)}>
+                            Добавить
+                        </Button>
+                    )
                 }
 
                 const v = row as VisitResponse
@@ -594,16 +807,18 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         columns.push({
             title: 'Врач',
             key: 'doctor',
-            render: (_: unknown, row: VisitResponse | GapRow) =>
+            render: (_: unknown, row: RowData) =>
                 isGap(row)
                     ? {children: null, props: {colSpan: 0}}
-                    : (
-                        <EntityLink
-                            kind="doctors"
-                            id={(row as VisitResponse).doctor_id}
-                            label={(row as VisitResponse).doctor_name}
-                        />
-                    ),
+                    : isSlot(row)
+                        ? '—'
+                        : (
+                            <EntityLink
+                                kind="doctors"
+                                id={(row as VisitResponse).doctor_id}
+                                label={(row as VisitResponse).doctor_name}
+                            />
+                        ),
         })
     }
     if (show?.procedure !== false) {
@@ -612,8 +827,9 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
             dataIndex: 'procedure',
             ellipsis: true,
             onCell: () => ({style: {cursor: 'text'}}),
-            render: (_: string | null | undefined, row: VisitResponse | GapRow) => {
+            render: (_: string | null | undefined, row: RowData) => {
                 if (isGap(row)) return {children: null, props: {colSpan: 0}}
+                if (isSlot(row)) return '—'
                 const v = row as VisitResponse
 
                 const isEditing = editingCell?.id === v.id && editingCell.field === 'procedure'
@@ -649,10 +865,12 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         columns.push({
             title: 'Кабинет',
             dataIndex: 'cabinet',
-            render: (v: string | null | undefined, row: VisitResponse | GapRow) =>
+            render: (v: string | null | undefined, row: RowData) =>
                 isGap(row)
                     ? {children: null, props: {colSpan: 0}}
-                    : (v ?? '—'),
+                    : isSlot(row)
+                        ? '—'
+                        : (v ?? '—'),
         })
     }
     if (show?.cost !== false) {
@@ -662,8 +880,9 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
             width: 110,
             align: 'right',
             onCell: () => ({style: {cursor: 'text'}}),
-            render: (_: number | null | undefined, row: VisitResponse | GapRow) => {
+            render: (_: number | null | undefined, row: RowData) => {
                 if (isGap(row)) return {children: null, props: {colSpan: 0}}
+                if (isSlot(row)) return '—'
                 const v = row as VisitResponse
 
                 const isEditing = editingCell?.id === v.id && editingCell.field === 'cost'
@@ -704,8 +923,9 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
             dataIndex: 'status',
             width: 56,
             align: 'center',
-            render: (s: VisitStatusEnum, row: VisitResponse | GapRow) => {
+            render: (s: VisitStatusEnum, row: RowData) => {
                 if (isGap(row)) return {children: null, props: {colSpan: 0}}
+                if (isSlot(row)) return '—'
 
                 const v = row as VisitResponse
                 return (
@@ -738,8 +958,9 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         columns.push({
             title: 'Действия',
             width: 150,
-            render: (_: unknown, row: VisitResponse | GapRow) => {
+            render: (_: unknown, row: RowData) => {
                 if (isGap(row)) return {children: null, props: {colSpan: 0}}
+                if (isSlot(row)) return null
 
                 const v = row as VisitResponse
                 return (
@@ -854,6 +1075,94 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
         }
     }
 
+    const openSlotForm = useCallback((slot: SlotRow) => {
+        const start = dayjs(slot.start_date)
+        setEditing(null)
+        setOpen(true)
+        form.resetFields()
+        const maybeDuration = DURATIONS.includes(slot.durationMinutes as DurationMin)
+            ? (slot.durationMinutes as DurationMin)
+            : undefined
+        form.setFieldsValue({
+            client_id: context?.clientId,
+            doctor_id: context?.doctorId ?? effDoctorId,
+            date: start,
+            time_start: start,
+            duration: maybeDuration ?? undefined,
+        })
+    }, [context?.clientId, context?.doctorId, effDoctorId, form])
+
+    const openScheduleModal = useCallback((mode: 'create' | 'update') => {
+        const {h: minH, m: minM} = parseHHMM(MIN_TIME)
+        const {h: maxH, m: maxM} = parseHHMM(MAX_TIME)
+        const baseDay = (day ?? (scheduleData ? dayjs(scheduleData.date) : dayjs())).startOf('day')
+
+        scheduleForm.resetFields()
+
+        if (mode === 'update' && scheduleData) {
+            const {h: startH, m: startM, s: startS} = parseHHMMSS(scheduleData.start_time)
+            const {h: endH, m: endM, s: endS} = parseHHMMSS(scheduleData.end_time)
+            scheduleForm.setFieldsValue({
+                start_time: baseDay.clone().hour(startH).minute(startM).second(startS),
+                end_time: baseDay.clone().hour(endH).minute(endM).second(endS),
+                duration: parseDurationMinutes(scheduleData.duration) ?? 10,
+            })
+        } else {
+            scheduleForm.setFieldsValue({
+                start_time: baseDay.clone().hour(minH).minute(minM),
+                end_time: baseDay.clone().hour(maxH).minute(maxM),
+                duration: 10,
+            })
+        }
+
+        setScheduleModalMode(mode)
+        setScheduleModalOpen(true)
+    }, [MIN_TIME, MAX_TIME, day, parseHHMM, scheduleData, parseHHMMSS, parseDurationMinutes, scheduleForm])
+
+    const submitSchedule = useCallback(async () => {
+        if (!effDoctorId || !day) {
+            message.warning('Выберите врача и дату для разлиновки')
+            return
+        }
+
+        const v = await scheduleForm.validateFields()
+        if (!v.start_time || !v.end_time || !v.duration) return
+
+        const duration = toDurationString(v.duration)
+
+        if (scheduleModalMode === 'update') {
+            const body: ScheduleUpdateRequest = {
+                start_time: v.start_time.format('HH:mm:ss'),
+                end_time: v.end_time.format('HH:mm:ss'),
+                duration,
+            }
+            updateScheduleMut.mutate({
+                date: day.format('YYYY-MM-DD'),
+                doctorId: effDoctorId,
+                body,
+            })
+        } else {
+            const body: ScheduleCreateRequest = {
+                doctor_id: effDoctorId,
+                date: day.format('YYYY-MM-DD'),
+                start_time: v.start_time.format('HH:mm:ss'),
+                end_time: v.end_time.format('HH:mm:ss'),
+                duration,
+            }
+
+            createScheduleMut.mutate(body)
+        }
+    }, [createScheduleMut, day, effDoctorId, scheduleForm, scheduleModalMode, toDurationString, updateScheduleMut])
+
+    const handleDeleteSchedule = useCallback(() => {
+        if (!effDoctorId || !day) {
+            message.warning('Выберите врача и дату для удаления разлиновки')
+            return
+        }
+
+        deleteScheduleMut.mutate({date: day.format('YYYY-MM-DD'), doctorId: effDoctorId})
+    }, [day, deleteScheduleMut, effDoctorId])
+
     function resetFilters() {
         setClientId(context?.clientId)
         setDoctorId(context?.doctorId)
@@ -944,6 +1253,15 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
                             }
                         }}
                     />
+                    {isDoctorDayMode && scheduleData === null && !isScheduleLoading && (
+                        <Button
+                            type="dashed"
+                            onClick={() => openScheduleModal('create')}
+                            disabled={!day || !effDoctorId}
+                        >
+                            Разлиновать
+                        </Button>
+                    )}
                     {!isDoctorDayMode && (
                         <InputNumber
                             min={1}
@@ -973,11 +1291,42 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
                     </Typography.Text>
                     <Typography.Text strong>{totalCostDisplay}</Typography.Text>
                 </Space>
+                {isDoctorDayMode && scheduleData && (
+                    <Space size="small" align="center" wrap>
+                        <Typography.Text type="secondary">
+                            Разлиновка: {scheduleData.start_time.slice(0, 5)}–{scheduleData.end_time.slice(0, 5)} · шаг {parseDurationMinutes(scheduleData.duration)} мин
+                        </Typography.Text>
+                        <Switch
+                            checked={ignoreSchedule}
+                            onChange={(checked: boolean) => setIgnoreSchedule(checked)}
+                            size="small"
+                        />
+                        <Typography.Text type="secondary">Отобразить без разлиновки</Typography.Text>
+                        <Button size="small" onClick={() => openScheduleModal('update')} disabled={!day || !effDoctorId}>
+                            Изменить разлиновку
+                        </Button>
+                        <Popconfirm
+                            title="Удалить разлиновку?"
+                            onConfirm={handleDeleteSchedule}
+                            okText="Удалить"
+                            cancelText="Отмена"
+                        >
+                            <Button size="small" danger loading={deleteScheduleMut.isPending} disabled={!day || !effDoctorId}>
+                                Удалить разлиновку
+                            </Button>
+                        </Popconfirm>
+                    </Space>
+                )}
+                {isDoctorDayMode && scheduleData === null && !isScheduleLoading && (
+                    <Typography.Text type="secondary">
+                        Разлиновки для выбранного дня нет, отображаем стандартные интервалы.
+                    </Typography.Text>
+                )}
             </Space>
 
-            <Table<VisitResponse | GapRow>
-                rowKey={(r) => (isGap(r) ? r.id : (r as VisitResponse).id)}
-                loading={isLoading}
+            <Table<RowData>
+                rowKey={(r) => (isGap(r) ? r.id : isSlot(r) ? r.id : (r as VisitResponse).id)}
+                loading={isLoading || isScheduleLoading}
                 dataSource={tableData}
                 columns={columns}
                 pagination={
@@ -1004,6 +1353,58 @@ export default function VisitsManager({context, show, defaultLimit = 30, onTotal
                         }
                 }
             />
+
+            <Modal
+                title={scheduleModalMode === 'update' ? 'Изменить разлиновку' : 'Разлиновка'}
+                open={scheduleModalOpen}
+                onCancel={() => setScheduleModalOpen(false)}
+                onOk={submitSchedule}
+                okText="Сохранить"
+                cancelText="Отмена"
+                confirmLoading={createScheduleMut.isPending || updateScheduleMut.isPending}
+            >
+                <Form form={scheduleForm} layout="vertical">
+                    <Form.Item
+                        name="start_time"
+                        label="Начало рабочего дня"
+                        rules={[{required: true, message: 'Укажите время начала'}]}
+                    >
+                        <TimePicker
+                            format="HH:mm"
+                            minuteStep={5}
+                            disabledHours={disabledHoursForWorkday}
+                            hideDisabledOptions
+                            inputReadOnly
+                            needConfirm={false}
+                            showNow={false}
+                        />
+                    </Form.Item>
+
+                    <Form.Item
+                        name="end_time"
+                        label="Конец рабочего дня"
+                        rules={[{required: true, message: 'Укажите время окончания'}]}
+                    >
+                        <TimePicker
+                            format="HH:mm"
+                            minuteStep={5}
+                            disabledHours={disabledHoursForWorkday}
+                            hideDisabledOptions
+                            inputReadOnly
+                            needConfirm={false}
+                            showNow={false}
+                        />
+                    </Form.Item>
+
+                    <Form.Item
+                        name="duration"
+                        label="Длительность приёма (минуты)"
+                        rules={[{required: true, message: 'Укажите длительность'}]}
+                    >
+                        <InputNumber min={1} max={240} style={{width: '100%'}}/>
+                    </Form.Item>
+                </Form>
+            </Modal>
 
             <Modal
                 title={editing ? 'Редактировать приём' : 'Новый приём'}

--- a/web/src/lib/phone.ts
+++ b/web/src/lib/phone.ts
@@ -7,12 +7,6 @@ const ensureSevenPrefix = (digits: string): string => {
     return `7${digits}`
 }
 
-const applyPhoneMask = (digits: string): string => {
-    const padded = (digits + '__________').slice(0, 10)
-
-    return `+7 (${padded.slice(0, 3)}) ${padded.slice(3, 6)}-${padded.slice(6, 8)}-${padded.slice(8, 10)}`
-}
-
 export function formatPhoneNumber(value?: string | null): string {
     const rawDigits = cleanDigits(value ?? '')
     if (!rawDigits) return ''


### PR DESCRIPTION
## Summary
- add update/delete schedule API helpers and wire them into VisitsManager controls
- allow editing an existing schedule with prefilled modal inputs and support removing schedules entirely
- update schedule toggle label while keeping time pickers auto-applying selections

## Testing
- npm run build --prefix web

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6928a2b3bb9c83268970fe2c397563e8)